### PR TITLE
Add ability to disabled installer with envvar

### DIFF
--- a/src/ComposerSymlinker/SymlinkerPlugin.php
+++ b/src/ComposerSymlinker/SymlinkerPlugin.php
@@ -15,6 +15,11 @@ class SymlinkerPlugin implements PluginInterface
      */
     public function activate(Composer $composer, IOInterface $io)
     {
+        if (!empty(getenv('DISABLE_SYMLINKER'))) {
+            $io->write('Found DISABLE_SYMLINKER envvar, disabling symlinker...');
+            return;
+        }
+
         $composer->getInstallationManager()->addInstaller(
             new LocalInstaller($io, $composer)
         );


### PR DESCRIPTION
### What is the problem / feature ?

Needed a way to disable the symlinker on the command line
### How did it get fixed / implemented ?
- Added `DISABLE_SYMLINKER` envvar
### How can someone test / see it ?

Checkout this branch in a repo that uses it, run `DISABLE_SYMLINKER=1 composer install`
